### PR TITLE
Sub 1658 trigger dag view issue fix

### DIFF
--- a/airflow/www/templates/airflow/trigger_dag.html
+++ b/airflow/www/templates/airflow/trigger_dag.html
@@ -61,7 +61,7 @@
                   {% endif %}
                       <td data-toggle="tooltip" title="{{task[param]['description']}}"><p>{{task[param]['name']}}</p></td>
                       {% if 'default' in task[param] %}
-                          <td><input type="text" name="conf.{{key}}.{{param}}"" value="{{task[param]['default']}}"></td>
+                          <td><input type="text" name="conf.{{key}}.{{param}}" value="{{task[param]['default']}}"></td>
                       {% else %}
                           <td><input type="text" name="conf.{{key}}.{{param}}"></td>
                       {% endif %}

--- a/airflow/www/templates/airflow/trigger_dag.html
+++ b/airflow/www/templates/airflow/trigger_dag.html
@@ -40,9 +40,9 @@
                   {% endif %}
                           <td data-toggle="tooltip" title="{{task[param]['description']}}"><p>{{task[param]['name']}}</p></td>
                       {% if 'required' in task[param] and task[param]['required'] == True %}
-                          <td><input type="text" size="50" name=conf.{{key}}.{{param}}></td>
+                          <td><input type="text" size="50" name="conf.{{key}}.{{param}}"></td>
                       {% else %}
-                          <td><input type="text" size="50" placeholder="optional" name=conf.{{key}}.{{param}}></td>
+                          <td><input type="text" size="50" placeholder="optional" name="conf.{{key}}.{{param}}"></td>
                       {% endif %}
                       </tr>
               {% endfor %}
@@ -61,9 +61,9 @@
                   {% endif %}
                       <td data-toggle="tooltip" title="{{task[param]['description']}}"><p>{{task[param]['name']}}</p></td>
                       {% if 'default' in task[param] %}
-                          <td><input type="text" name=conf.{{key}}.{{param}} value={{task[param]['default']}}></td>
+                          <td><input type="text" name="conf.{{key}}.{{param}}"" value="{{task[param]['default']}}"></td>
                       {% else %}
-                          <td><input type="text" name=conf.{{key}}.{{param}}></td>
+                          <td><input type="text" name="conf.{{key}}.{{param}}"></td>
                       {% endif %}
               </tr>
               {% endfor %}


### PR DESCRIPTION
There was an issue in trigger_dag view when displaying default parameter values. If there is space in default parameter value it is trimmed from there. 
For example if parameter value is "Marine Project #2", the displayed value is just "Marine". This happens because of missing quotes in html tag parameter values.


