### PR TITLE
SUB-1700 DAG auto refresh and progress bar

### DIFF
--- a/airflow/migrations/versions/4fb6c5c0c9c7_add_progress_to_task_instance.py
+++ b/airflow/migrations/versions/4fb6c5c0c9c7_add_progress_to_task_instance.py
@@ -1,0 +1,37 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add progress to task instance
+
+Revision ID: 4fb6c5c0c9c7
+Revises: d2ae31099d61
+Create Date: 2018-03-22 12:50:07.962098
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4fb6c5c0c9c7'
+down_revision = 'd2ae31099d61'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('task_instance', sa.Column('progress', sa.PickleType(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('task_instance', 'progress')

--- a/airflow/www/static/graph.css
+++ b/airflow/www/static/graph.css
@@ -57,7 +57,7 @@ div#svg_container {
  cursor: move;
 }
 
-#refresh_button {
+#refresh_button, #start_auto_refresh_button, #stop_auto_refresh_button {
     top: 15px;
     right: 15px;
     position: relative;

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -80,6 +80,16 @@
 <button class="btn btn-default pull-right" id="refresh_button">
     <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
 </button>
+<button class="btn btn-default pull-right" id="auto_refresh_button" style="display: none;">
+    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+</button>
+{% else %}
+<button class="btn btn-default pull-right" id="refresh_button" style="display: none;">
+    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+</button>
+<button class="btn btn-default pull-right" id="auto_refresh_button">
+    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+</button>
 {% endif %}
 <div id="svg_container">
 

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -76,9 +76,11 @@
         <span id="error_msg">Oops.</span>
 </div>
 <hr style="margin-bottom: 0px;"/>
+{% if refresh_rate|int == 0 %}
 <button class="btn btn-default pull-right" id="refresh_button">
     <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
 </button>
+{% endif %}
 <div id="svg_container">
 
     <svg width="{{ width }}" height="{{ height }}">
@@ -344,25 +346,29 @@
       $('#datatable_section').hide(1000);
     }
 
-    d3.select("#refresh_button").on("click",
-        function() {
-            $("#loading").css("display", "block");
-            $("div#svg_container").css("opacity", "0.2");
-            $.get(
-                "/admin/airflow/object/task_instances",
-                {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
-            .done(
-                function(task_instances) {
-                    update_nodes_states(JSON.parse(task_instances));
-                    $("#loading").hide();
-                    $("div#svg_container").css("opacity", "1");
-                    $('#error').hide();
-                }
-            ).fail(function(jqxhr, textStatus, err) {
-                error(textStatus + ': ' + err);
-            });
-        }
-    );
+    function refreshGraph() {
+        $("#loading").css("display", "block");
+        $("div#svg_container").css("opacity", "0.2");
+        $.get(
+            "/admin/airflow/object/task_instances",
+            {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
+        .done(
+            function(task_instances) {
+                update_nodes_states(JSON.parse(task_instances));
+                $("#loading").hide();
+                $("div#svg_container").css("opacity", "1");
+                $('#error').hide();
+            }
+        ).fail(function(jqxhr, textStatus, err) {
+            error(textStatus + ': ' + err);
+        });
+    }
+
+    {% if refresh_rate|int > 0 %}
+    window.setInterval(refreshGraph, {{ refresh_rate }})
+    {% else %}
+    d3.select("#refresh_button").on("click", refreshGraph);
+    {% endif %}
 
     </script>
 

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -27,6 +27,14 @@
     href="{{ url_for('static', filename='dagre.css') }}">
 <link rel="stylesheet" type="text/css"
     href="{{ url_for('static', filename='graph.css') }}">
+<style>
+    .progress {
+        height: 5px; 
+        width: 100%; 
+        margin-bottom: 0px;
+        margin-top: 5px;
+    }
+</style>
 {% endblock %}
 
 {% block body %}
@@ -76,19 +84,22 @@
         <span id="error_msg">Oops.</span>
 </div>
 <hr style="margin-bottom: 0px;"/>
-{% if refresh_rate|int == 0 %}
 <button class="btn btn-default pull-right" id="refresh_button">
-    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+    <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh DAG"></span>
 </button>
-<button class="btn btn-default pull-right" id="auto_refresh_button" style="display: none;">
-    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+{% if refresh_rate|int == 0 %}
+<button class="btn btn-default pull-right" id="stop_auto_refresh_button" style="display: none;" >
+    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true" title="Stop Auto Refresh"></span>
+</button>
+<button class="btn btn-default pull-right" id="start_auto_refresh_button">
+    <span class="glyphicon glyphicon-play-circle" aria-hidden="true" title="Start Auto Refresh"></span>
 </button>
 {% else %}
-<button class="btn btn-default pull-right" id="refresh_button" style="display: none;">
-    <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
+<button class="btn btn-default pull-right" id="stop_auto_refresh_button">
+    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true" title="Stop Auto Refresh"></span>
 </button>
-<button class="btn btn-default pull-right" id="auto_refresh_button">
-    <span class="glyphicon glyphicon-ban-circle" aria-hidden="true"></span>
+<button class="btn btn-default pull-right" id="start_auto_refresh_button" style="display: none;" >
+    <span class="glyphicon glyphicon-play-circle" aria-hidden="true" title="Start Auto Refresh"></span>
 </button>
 {% endif %}
 <div id="svg_container">
@@ -268,7 +279,7 @@
     function inject_node_ids(tasks) {
         $.each(tasks, function(task_id, task) {
             $('tspan').filter(function(index) { return $(this).text() === task_id; })
-                    .parent().parent().parent()
+                    .parent().parent().parent().parent().parent().parent()
                     .attr("id", task_id);
         });
     }
@@ -278,7 +289,7 @@
     function update_nodes_states(task_instances) {
         $.each(task_instances, function(task_id, ti) {
           $('tspan').filter(function(index) { return $(this).text() === task_id; })
-            .parent().parent().parent()
+            .parent().parent().parent().parent().parent().parent()
             .attr("class", "node enter " + ti.state)
             .attr("data-toggle", "tooltip")
             .attr("data-original-title", function(d) {
@@ -295,6 +306,13 @@
               tt += "State: " + ti.state + "<br>";
               return tt;
             });
+            var exist = $('#progress_' + task_id).length;
+            if (exist > 0) {
+                $('#progress_completed_' + task_id).width(ti.progress.completed.toString() + '%');
+                $('#progress_warning_' + task_id).width(ti.progress.warning.toString() + '%');
+                $('#progress_failed_' + task_id).width(ti.progress.failed.toString() + '%');
+                $('#progress_ready_' + task_id).width(ti.progress.ready.toString() + '%');
+            }
         });
     }
 
@@ -374,11 +392,34 @@
         });
     }
 
+    function autoRefreshGraph() {
+        $.get(
+            "/admin/airflow/object/task_instances",
+            {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
+        .done(
+            function(task_instances) {
+                update_nodes_states(JSON.parse(task_instances));
+            }
+        );
+    }
+
+    var refresh_interval = null;
     {% if refresh_rate|int > 0 %}
-    window.setInterval(refreshGraph, {{ refresh_rate }})
-    {% else %}
-    d3.select("#refresh_button").on("click", refreshGraph);
+    refresh_interval = window.setInterval(autoRefreshGraph, {{ refresh_rate }})
     {% endif %}
+    d3.select("#refresh_button").on("click", refreshGraph);
+
+    d3.select("#stop_auto_refresh_button").on("click", function () {
+        clearInterval(refresh_interval);
+        $("#stop_auto_refresh_button").hide();
+        $("#start_auto_refresh_button").show();
+    });
+
+    d3.select("#start_auto_refresh_button").on("click", function () {
+        refresh_interval = window.setInterval(autoRefreshGraph, {{ refresh_rate }})
+        $("#start_auto_refresh_button").hide();
+        $("#stop_auto_refresh_button").show();
+    });
 
     </script>
 

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -20,6 +20,11 @@
 
 {% block body %}
   {{ super() }}
+
+  <div id="error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">
+      <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+      <span id="error_msg">Oops.</span>
+  </div>
   <h4>{{ title }}</h4>
   <ul class="nav nav-pills" role="tablist">
     {% for log in logs %}
@@ -31,10 +36,53 @@
     {% endfor %}
   </ul>
   <div class="tab-content">
+    <button class="btn btn-default pull-right refresh_button" style="display: inline-flex;">
+        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+    </button>
     {% for log in logs %}
       <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
         <pre id="attempt-{{ loop.index }}">{{ log }}</pre>
       </div>
     {% endfor %}
+    <img id="loading" alt="spinner" src="{{ url_for('static', filename='loading.gif') }}"
+         style="margin: auto; display: none;">
+    <button class="btn btn-default pull-right refresh_button" style="margin-bottom: 10px;">
+        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+    </button>
   </div>
+{% endblock %}
+
+{% block tail %}
+{{ super() }}
+<script>
+    function error(msg) {
+        $('#error_msg').html(msg);
+        $('#error').show();
+        reset();
+    }
+
+    function reset() {
+        $('#loading').css('display', 'none');
+        $('div.tab-pane.active').show();
+        $(".refresh_button").removeClass('disabled');
+    }
+
+    $(".refresh_button").on("click", function() {
+        $("#loading").css('display', 'block');
+        $("div.tab-pane.active").hide();
+        $('#error').hide();
+        $(".refresh_button").addClass('disabled');
+        $.get(decodeURIComponent(window.location.href) + '&log_id=' + $("div.tab-pane.active").attr('id')
+        ).done(
+            function(data) {
+                $("div.tab-pane.active").html(data);
+                reset();
+                window.scrollTo(0, document.body.scrollHeight);
+            }
+        ).fail(function(jqxhr, textStatus, err) {
+            error(textStatus + ': ' + err);
+        });
+    });
+
+</script>
 {% endblock %}

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -35,9 +35,6 @@
       </li>
     {% endfor %}
   </ul>
-  <button class="btn btn-default pull-right refresh_button" style="display: inline-flex;">
-      <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
-  </button>
   <div class="tab-content">
     {% for log in logs %}
       <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
@@ -47,7 +44,7 @@
     <img id="loading" alt="spinner" src="{{ url_for('static', filename='loading.gif') }}"
          style="margin: auto; display: none;">
   </div>
-  <button class="btn btn-default pull-right refresh_button" style="margin-bottom: 10px;">
+  <button class="btn btn-default pull-left refresh_button" style="margin-bottom: 10px;">
       <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
   </button>
 {% endblock %}
@@ -63,20 +60,18 @@
 
     function reset() {
         $('#loading').css('display', 'none');
-        $('div.tab-pane.active').show();
         $(".refresh_button").removeClass('disabled');
     }
 
     $(".refresh_button").on("click", function() {
         $("#loading").css('display', 'block');
-        $("div.tab-pane.active").hide();
         $('#error').hide();
         $(".refresh_button").addClass('disabled');
         $.get(decodeURIComponent(window.location.href) + '&log_id=' + $("div.tab-pane.active").attr('id')
         ).done(
             function(data) {
                 var attempt = $("div.tab-pane.active").attr('id')
-                $("pre#attempt-" + attempt).html(data);
+                $("pre#attempt-" + attempt).text(data.replace(/\r\n/g, '\n'));
                 reset();
                 window.scrollTo(0, document.body.scrollHeight);
             }

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -35,10 +35,10 @@
       </li>
     {% endfor %}
   </ul>
+  <button class="btn btn-default pull-right refresh_button" style="display: inline-flex;">
+      <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+  </button>
   <div class="tab-content">
-    <button class="btn btn-default pull-right refresh_button" style="display: inline-flex;">
-        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
-    </button>
     {% for log in logs %}
       <div role="tabpanel" class="tab-pane {{ 'active' if loop.last else '' }}" id="{{ loop.index }}">
         <pre id="attempt-{{ loop.index }}">{{ log }}</pre>
@@ -46,10 +46,10 @@
     {% endfor %}
     <img id="loading" alt="spinner" src="{{ url_for('static', filename='loading.gif') }}"
          style="margin: auto; display: none;">
-    <button class="btn btn-default pull-right refresh_button" style="margin-bottom: 10px;">
-        <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
-    </button>
   </div>
+  <button class="btn btn-default pull-right refresh_button" style="margin-bottom: 10px;">
+      <span class="glyphicon glyphicon-refresh" aria-hidden="true" title="Refresh Logs"></span>
+  </button>
 {% endblock %}
 
 {% block tail %}
@@ -75,7 +75,8 @@
         $.get(decodeURIComponent(window.location.href) + '&log_id=' + $("div.tab-pane.active").attr('id')
         ).done(
             function(data) {
-                $("div.tab-pane.active").html(data);
+                var attempt = $("div.tab-pane.active").attr('id')
+                $("pre#attempt-" + attempt).html(data);
                 reset();
                 window.scrollTo(0, document.body.scrollHeight);
             }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -715,6 +715,13 @@ class Airflow(BaseView):
                 logs = ["Task log handler {} does not support read logs.\n{}\n" \
                             .format(task_log_reader, str(e))]
 
+        if request.is_xhr:
+            log_id = int(request.args.get('log_id'))
+            log = logs[log_id - 1]
+            if PY2 and not isinstance(log, unicode):
+                log = log.decode('utf-8')
+            return log
+
         for i, log in enumerate(logs):
             if PY2 and not isinstance(log, unicode):
                 logs[i] = log.decode('utf-8')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1418,6 +1418,10 @@ class Airflow(BaseView):
         session.close()
         doc_md = markdown.markdown(dag.doc_md) if hasattr(dag, 'doc_md') and dag.doc_md else ''
 
+        refresh_rate = conf.getint('webserver', 'graph_refresh_rate')
+        if not refresh_rate:
+            refresh_rate = 0
+
         return self.render(
             'airflow/graph.html',
             dag=dag,
@@ -1437,7 +1441,8 @@ class Airflow(BaseView):
             task_instances=json.dumps(task_instances, indent=2),
             tasks=json.dumps(tasks, indent=2),
             nodes=json.dumps(nodes, indent=2),
-            edges=json.dumps(edges, indent=2), )
+            edges=json.dumps(edges, indent=2), 
+            refresh_rate=refresh_rate)
 
     @expose('/duration')
     @login_required


### PR DESCRIPTION
### DAG graph automatic refresh ###
Now the DAG graph is refreshed automatically in user configured interval. User has to add `graph_refresh_rate` configuration to `[webserver]` section in airflow.cfg in order this feature to be enabled. `graph_refresh_rate` is in seconds. If set to zero it will also disable auto refresh. User can temporarily disable/enable auto refresh in DAG graph. 

### DAG task progress bar ###
If DAG auto refresh is enabled, a progress bar is shown for tasks that support "task progress" (e.g. BatchOperator, RoamesApiCallOperator). Progress has for parts (ready, warning, completed, failed) that needs to be updated in operator `execute` method.  

### Refresh button to Log window ###
A new refresh button added to bottom of log pane in Log window to manually refresh the logs. It only requests for the logs for specific "task try", so response time is reduced and load to webserver is minimum than the whole page refresh. 
