### PR TITLE
Implement auth0 backend

### DIFF
--- a/airflow/api/auth/backend/auth0_auth.py
+++ b/airflow/api/auth/backend/auth0_auth.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+from future.standard_library import install_aliases
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+install_aliases()
+
+import requests
+
+from airflow import configuration as conf
+
+from flask import Response
+from flask import _request_ctx_stack as stack
+from flask import make_response
+from flask import request
+from functools import wraps
+
+AUTH0_DOMAIN = None
+client_auth = None
+
+
+log = LoggingMixin().log
+
+
+def get_config_param(param):
+    return str(conf.get('auth0', param))
+
+
+def init_app(app):
+    global AUTH0_DOMAIN
+
+    AUTH0_DOMAIN = get_config_param('domain')
+
+
+def _unauthorized():
+    """
+    Indicate that authorization is required
+    :return:
+    """
+    return Response("Unauthorized", 401, {"WWW-Authenticate": "Negotiate"})
+
+
+def _forbidden():
+    return Response("Forbidden", 403)
+
+
+def requires_authentication(function):
+    """Determines if the Access Token is valid
+    """
+    @wraps(function)
+    def decorated(*args, **kwargs):
+        auth = request.headers.get("Authorization", None)
+        if not auth:
+            return _unauthorized()
+
+        parts = auth.split()
+
+        if parts[0].lower() != "bearer":
+            return _unauthorized()
+        elif len(parts) == 1:
+            return _unauthorized()
+        elif len(parts) > 2:
+            return _unauthorized()
+
+        token = parts[1]
+        url = "https://%s/tokeninfo?id_token=%s" % (AUTH0_DOMAIN, token)
+        response = requests.get(url)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            return _unauthorized()
+
+        stack.top.current_user = response.json()
+        response = function(*args, **kwargs)
+        response = make_response(response)
+        return response
+
+    return decorated

--- a/airflow/contrib/auth/backends/auth0_auth.py
+++ b/airflow/contrib/auth/backends/auth0_auth.py
@@ -1,0 +1,190 @@
+# Copyright 2018 Prabodha Rodrigo (prabodha.rodrigo@roames.com.au)
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import flask_login
+
+# Need to expose these downstream
+# pylint: disable=unused-import
+from flask_login import (current_user,
+                         logout_user,
+                         login_required,
+                         login_user)
+# pylint: enable=unused-import
+
+from flask import url_for, redirect, request
+
+from flask_oauthlib.client import OAuth
+
+from airflow import models, configuration, settings
+from airflow.utils.db import provide_session
+from airflow.utils.log.logging_mixin import LoggingMixin
+import requests
+
+log = LoggingMixin().log
+
+
+def get_config_param(param):
+    return str(configuration.conf.get('auth0', param))
+
+
+class Auth0User(models.User):
+
+    def __init__(self, user):
+        self.user = user
+
+    def is_active(self):
+        '''Required by flask_login'''
+        return True
+
+    def is_authenticated(self):
+        '''Required by flask_login'''
+        return True
+
+    def is_anonymous(self):
+        '''Required by flask_login'''
+        return False
+
+    def get_id(self):
+        '''Returns the current user id as required by flask_login'''
+        return self.user.get_id()
+
+    def data_profiling(self):
+        '''Provides access to data profiling tools'''
+        return True
+
+    def is_superuser(self):
+        '''Access all the things'''
+        return True
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+class Auth0AuthBackend(object):
+
+    def __init__(self):
+        # self.google_host = get_config_param('host')
+        self.login_manager = flask_login.LoginManager()
+        self.login_manager.login_view = 'airflow.login'
+        self.flask_app = None
+        self.auth0_oauth = None
+        self.api_rev = None
+        self.auth0_domain = get_config_param('domain')
+
+    def init_app(self, flask_app):
+        self.flask_app = flask_app
+
+        self.login_manager.init_app(self.flask_app)
+
+        self.auth0_oauth = OAuth(self.flask_app).remote_app(
+            'auth0',
+            consumer_key=get_config_param('client_id'),
+            consumer_secret=get_config_param('client_secret'),
+            base_url='https://%s/' % self.auth0_domain,
+            request_token_url=None,  # Always None in OAuth2
+            access_token_method='POST',
+            access_token_url='https://%s/oauth/token' % self.auth0_domain,
+            authorize_url='https://%s/authorize' % self.auth0_domain,
+            request_token_params={'scope': ['openid profile', 'email']})
+
+        self.login_manager.user_loader(self.load_user)
+
+        self.flask_app.add_url_rule(get_config_param('auth0_callback_route'),
+                                    'auth0_callback',
+                                    self.auth0_callback)
+
+    def login(self, request):
+        log.debug('Redirecting user to Auth0 login')
+        return self.auth0_oauth.authorize(callback=url_for(
+            'auth0_callback',
+            _external=True,
+            _scheme='https'),
+            state=request.args.get('next') or request.referrer or None)
+        # auth0.authorize_redirect(redirect_uri='YOUR_CALLBACK_URL', audience='https://YOUR_AUTH0_DOMAIN/userinfo')
+
+    @provide_session
+    def load_user(self, userid, session=None):
+        if not userid or userid == 'None':
+            return None
+
+        user = session.query(models.User).filter(
+            models.User.id == int(userid)).first()
+        return Auth0User(user)
+
+    @provide_session
+    def auth0_callback(self, session=None):
+        log.debug('Auth0 callback called')
+
+        next_url = request.args.get('state') or url_for('admin.index')
+
+        resp = self.auth0_oauth.authorized_response()
+
+        try:
+            if resp is None:
+                raise AuthenticationError(
+                    'Null response from Auth0, denying access.'
+                )
+
+            user_info_url = 'https://%s/userinfo' % self.auth0_domain
+            headers = {'authorization': 'Bearer ' + resp['access_token']}
+            resp = requests.get(user_info_url, headers=headers)
+
+            if not resp or resp.status != 200:
+                raise AuthenticationError(
+                    'Failed to fetch user profile, status ({0})'.format(
+                        resp.status if resp else 'None'))
+
+            userinfo = resp.json()
+
+            # Store the user information in flask session.
+            session['jwt_payload'] = userinfo
+            session['profile'] = {
+                'user_id': userinfo['sub'],
+                'name': userinfo['name'],
+                'picture': userinfo['picture']
+            }
+
+            username = resp.data['name']
+            email = resp.data['email']
+
+        except AuthenticationError:
+            return redirect(url_for('airflow.noaccess'))
+
+        user = session.query(models.User).filter(
+            models.User.username == username).first()
+
+        if not user:
+            user = models.User(
+                username=username,
+                email=email,
+                is_superuser=False)
+
+        session.merge(user)
+        session.commit()
+        login_user(Auth0User(user))
+        session.commit()
+
+        return redirect(next_url)
+
+
+login_manager = Auth0AuthBackend()
+
+
+def login(self, request):
+    return login_manager.login(request)

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -135,7 +135,7 @@ class TriggerRuleDep(BaseTIDep):
             if tr == TR.ALL_SUCCESS:
                 if upstream_failed or failed:
                     ti.set_state(State.UPSTREAM_FAILED, session)
-                elif skipped:
+                elif skipped == upstream:
                     ti.set_state(State.SKIPPED, session)
             elif tr == TR.ALL_FAILED:
                 if successes or skipped:
@@ -162,7 +162,7 @@ class TriggerRuleDep(BaseTIDep):
                     "upstream_tasks_state={1}, upstream_task_ids={2}"
                     .format(tr, upstream_tasks_state, task.upstream_task_ids))
         elif tr == TR.ALL_SUCCESS:
-            num_failures = upstream - successes
+            num_failures = upstream - (successes + skipped)
             if num_failures > 0:
                 yield self._failing_status(
                     reason="Task's trigger rule '{0}' requires all upstream "

--- a/airflow/www/templates/airflow/trigger_dag.html
+++ b/airflow/www/templates/airflow/trigger_dag.html
@@ -27,11 +27,22 @@
     <form action="{{ url_for('airflow.trigger_with_conf') }}" method="post">
       <input type="hidden" value="{{ dag.dag_id }}" name="dag_id">
       <input name=_csrf_token type=hidden value="{{ csrf_token() }}">
-      <h4 class="pull-right">
-          <a href="#" class="btn btn-info" onclick="$(this).closest('form').submit()">Go!</a>
-      </h4>
       <br>
-      <br>
+      <table class="pull-right">
+        <tr>
+          <td data-toggle="tooltip" title="Set custom run_id for this workflow run">
+            <label class="control-label" style="padding: 5px">Workflow Run Id  </label>
+          </td>
+          <td data-toggle="tooltip" title="Set custom run_id for this workflow run">
+            <input class="form-control" id="run_id" name="run_id" type="text" size="50" value="{{run_id}}">
+          </td>
+          <td>
+            <h4 class="pull-right">
+                <a href="#" class="btn btn-info" onclick="$(this).closest('form').submit()">Go!</a>
+            </h4>
+          </td>
+        </tr>
+      </table>
       <table class="table table-striped">
           {% for key, task in arguments.iteritems() %}
               {% for index, param in enumerate(task) %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -931,6 +931,9 @@ class Airflow(BaseView):
                     arguments.setdefault(task, {})[param] = dag.params[task][param]
                     num_args = num_args + 1
 
+        execution_date = datetime.utcnow()
+        run_id = "manual__{0}".format(execution_date.isoformat())
+
         return self.render(
             'airflow/trigger_dag.html', dag=dag, title=title, enumerate=enumerate, len=len,
             root=request.args.get('root'),
@@ -938,7 +941,8 @@ class Airflow(BaseView):
             enable_all_views=conf.getboolean('roames', 'enable_all_views'),
             arguments=arguments,
             options=options,
-            num_args=num_args
+            num_args=num_args,
+            run_id=run_id
         )
 
     @expose('/trigger_with_conf', methods=["POST"])
@@ -968,6 +972,8 @@ class Airflow(BaseView):
                 task = input.split('.')[1]
                 param = input.split('.')[2]
                 run_conf.setdefault(task, {})[param] = request.form[input]
+            elif input == 'run_id':
+                run_id = request.form[input]
         dag.create_dagrun(
             run_id=run_id,
             execution_date=execution_date,
@@ -1465,7 +1471,7 @@ class Airflow(BaseView):
             task_instances=json.dumps(task_instances, indent=2),
             tasks=json.dumps(tasks, indent=2),
             nodes=json.dumps(nodes, indent=2),
-            edges=json.dumps(edges, indent=2), 
+            edges=json.dumps(edges, indent=2),
             refresh_rate=refresh_rate)
 
     @expose('/duration')


### PR DESCRIPTION
Implementation of basic authentication support through Auth0. The implementation includes auth support for UI login and experimental API endpoints. Following configurations need to be provided if auth0 backend is enabled.

```
[webserver]
auth_backend = airflow.contrib.auth.backends.auth0_auth

[api]
auth_backend = airflow.api.auth.backend.auth0_auth

[auth0]
client_id = XXXXXXX
client_secret = XXXXXXXX
auth0_callback_route = /auth0callback
auth0_callback_scheme = https
domain = my-domain.auth0.com
```

Note that currently we do not use any kind of token caching or other performance optimisations. This changes are purely intended  to get the basic Auth0 support into Airflow.