### PR TITLE
MAR-911: Alleviate most Airflow concurrency issues by using milliseco…

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -85,7 +85,7 @@ def trigger_dag(
         run_id=None,
         conf=None,
         execution_date=None,
-        replace_microseconds=True,
+        replace_microseconds=False,
         trigger_sub_dags=True
 ):
     dag_model = DagModel.get_current(dag_id)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -4219,7 +4219,7 @@ class DAG(BaseDag, LoggingMixin):
         # state is None at the moment of creation
         run.verify_integrity(session=session)
 
-        run.refresh_from_db()
+        run.refresh_from_db(session=session)
 
         return run
 
@@ -4746,6 +4746,7 @@ class DagStat(Base):
             log = LoggingMixin().log
             log.warning("Could not update dag stats for %s", dag_id)
             log.exception(e)
+            raise
 
     @staticmethod
     @provide_session


### PR DESCRIPTION
…nd accuracy in execution date

The stack trace pointed to an issue in DAGRun.refresh_from_db(),
but the issue was actually a (silenced) session rollback in set_dirty().
This error was related to multiple DAG runs having the same execution
date (since millisecond precision was turned off by default, therefore
limiting the maximum throughpout to 1 dag run per dag id and per
second).
The error is now explicitly raised, and the millisecond accuracy
enforced.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
