### PR TITLE
PIPE-117 API endpoint to list all DAGS

### DIFF
--- a/airflow/api/common/experimental/list_dags.py
+++ b/airflow/api/common/experimental/list_dags.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, List
+from airflow.models import DagBag
+
+
+def list_dags(argument: Any, value: Any) -> List[Any]:
+    """Return a list of Dags matching the given DAG default argument value."""
+    dagbag = DagBag()
+
+    def should_keep_dag(dag: Any) -> bool:
+        return any(
+            [
+                not argument or not value,
+                argument in dag.default_args and dag.default_args[argument] == value,
+            ],
+        )
+
+    return [
+        dag_id
+        for (dag_id, dag) in dagbag.dags.items()
+        if should_keep_dag(dag)
+    ]

--- a/airflow/www_rbac/api/experimental/endpoints.py
+++ b/airflow/www_rbac/api/experimental/endpoints.py
@@ -26,6 +26,7 @@ from airflow.api.common.experimental.get_task_instance import get_task_instance
 from airflow.api.common.experimental.get_dag_by_id import get_dag_by_id
 from airflow.api.common.experimental.get_dag_run_state import get_dag_run_state
 from airflow.api.common.experimental.get_dag_run_by_id import get_dag_run_by_id
+from airflow.api.common.experimental.list_dags import list_dags
 from airflow.exceptions import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils import timezone
@@ -40,6 +41,34 @@ _log = LoggingMixin().log
 requires_authentication = airflow.api.api_auth.requires_authentication
 
 api_experimental = Blueprint('api_experimental', __name__)
+
+
+@csrf.exempt
+@api_experimental.route('/dags', methods=['GET'])
+@requires_authentication
+def get_all_dags():
+    """
+    List all the Dags. Optionally matching given "DAG default argument" value.
+    """
+    argument = request.args.get('argument')
+    value = request.args.get('value')
+
+    if (argument and not value) or (not argument and value):
+        _log.error("both `argument` and `value` query parameters required")
+        response = jsonify(error="{}".format(
+            "both `argument` and `value` query parameters required"))
+        response.status_code = 400
+        return response
+
+    try:
+        dags = list_dags(argument, value)
+    except Exception as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = 500
+        return response
+
+    return jsonify(dags)
 
 
 @csrf.exempt


### PR DESCRIPTION
New API endpoint to get all DAGs. Optionally user can provide filters based on the DAGs' `default_args`. 
Default arg is a python dict we pass when creating a new DAG

`default_args = {'owner': 'pipe_inspection',
                'start_date': airflow.utils.dates.days_ago(0),
                'provide_context': True}`

It is possible to pass any attribute:value to this dictionary and refer them later in DAG. This endpoint supports filtering DAGs based on this dictionary value. For example we can pass "Project Name/ID" as an attribute and query all DAGs for particular project.