### PR TITLE
PIPE-1561: Migrate to Python3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,7 @@ password = [
     'flask-bcrypt>=0.7.1',
 ]
 pinot = ['pinotdb==0.1.1']
-postgres = ['psycopg2-binary>=2.7.4,<2.8']
+postgres = ['psycopg2-binary>=2.8,<2.9']
 qds = ['qds-sdk>=1.9.6']
 rabbitmq = ['librabbitmq>=1.6.1']
 redis = ['redis~=3.2']


### PR DESCRIPTION
psycopg2.7 does not compile on Python3.8, but work fine with v2.8 or
higher.